### PR TITLE
Dockerfile - Add configure step for radare2-mcp build

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN git clone --depth 1 https://github.com/radareorg/radare2.git && \
 
 RUN git clone --depth 1 https://github.com/radareorg/radare2-mcp.git && \
     cd radare2-mcp && \
+    ./configure && \
     make && \
     cp -f src/r2mcp /usr/local/bin/
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
```
Missing step in the Dockerfile. After cloning the repo and running the docker file:
Cloning into 'radare2-mcp'...
make -C src all
make[1]: Entering directory '/build/radare2-mcp/src'
Checking dependencies...
✓ All dependencies are satisfied.
cc -Wall -Wextra -g -I/usr/local/include/libr   -c -o main.o main.c
main.c:1:10: fatal error: config.h: No such file or directory
    1 | #include "config.h"
      |          ^~~~~~~~~~
compilation terminated.
make[1]: Leaving directory '/build/radare2-mcp/src'
make[1]: *** [<builtin>: main.o] Error 1
make: *** [Makefile:4: all] Error 2
The command '/bin/sh -c git clone --depth 1 https://github.com/radareorg/radare2-mcp.git &&     cd radare2-mcp &&     make &&     cp -f src/r2mcp /usr/local/bin/' returned a non-zero code: 2
```

Make called without configure
