### PR TITLE
Fix build for radare2 5.9.8 compatibility

### DIFF
--- a/src/dsltest.c
+++ b/src/dsltest.c
@@ -131,13 +131,13 @@ static int run_statement(ServerState *ss, char *stmt, RCore *core) {
 				if (text_end) {
 					char *text = r_str_ndup (text_start, text_end - text_start);
 					r_str_replace_in (text, -1, "\\n", "\n", true);
-					r_cons_printf (core->cons, "%s\n", text);
+					r_cons_printf ("%s\n", text);
 					free (text);
 				} else {
-					r_cons_printf (core->cons, "(malformed text in response)\n");
+					r_cons_printf ("(malformed text in response)\n");
 				}
 			} else {
-				r_cons_printf (core->cons, "(no text in response)\n");
+				r_cons_printf ("(no text in response)\n");
 			}
 		} else {
 			printf ("[DSL] %s -> %s\n", tool, res);
@@ -145,7 +145,7 @@ static int run_statement(ServerState *ss, char *stmt, RCore *core) {
 		free (res);
 	} else {
 		if (core) {
-			r_cons_printf (core->cons, "(no result)\n");
+			r_cons_printf ("(no result)\n");
 		} else {
 			printf ("[DSL] %s -> (no result)\n", tool);
 		}

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -12,6 +12,11 @@ typedef struct r2mcp_data_t {
 	ServerState *ss;
 } R2mcpData;
 
+// Global data for old API (no session support)
+static R2mcpData *global_data = NULL;
+
+#if R2_VERSION_NUMBER >= 50909
+
 static bool r2mcp_call(RCorePluginSession *cps, const char *input) {
 	RCore *core = cps->core;
 	R2mcpData *data = cps->data;
@@ -60,6 +65,63 @@ static bool r2mcp_fini(RCorePluginSession *cps) {
 	return true;
 }
 
+#else // R2_VERSION_NUMBER < 50909 (old API)
+
+static int r2mcp_call(void *user, const char *input) {
+	RCore *core = (RCore *)user;
+
+	if (!r_str_startswith (input, "r2mcp")) {
+		return false;
+	}
+
+	// Skip "r2mcp" command name
+	const char *args = r_str_trim_head_ro (input + strlen ("r2mcp"));
+
+	// Initialize global data if not already done
+	if (!global_data) {
+		global_data = R_NEW0 (R2mcpData);
+	}
+
+	// Initialize server state if not already done
+	if (!global_data->ss) {
+		global_data->ss = R_NEW0 (ServerState);
+		// Set up the core reference
+		global_data->ss->rstate.core = core;
+		global_data->ss->rstate.file_opened = true; // We're already in r2 with a file
+	}
+
+	if (R_STR_ISEMPTY (args)) {
+		tools_print_table (global_data->ss);
+	} else {
+		if (r2mcp_run_dsl_tests (global_data->ss, args, core) != 0) {
+			R_LOG_ERROR ("Error executing r2mcp command");
+		}
+	}
+
+	return true;
+}
+
+static int r2mcp_init(void *user, const char *input) {
+	(void)user;
+	(void)input;
+	return true;
+}
+
+static int r2mcp_fini(void *user, const char *input) {
+	(void)user;
+	(void)input;
+	if (global_data) {
+		if (global_data->ss) {
+			free (global_data->ss);
+		}
+		free (global_data);
+		global_data = NULL;
+	}
+	return true;
+}
+
+#endif
+
 // PLUGIN Definition Info
 RCorePlugin r_core_plugin_r2mcp = {
 	.meta = {
@@ -78,6 +140,8 @@ R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_CORE,
 	.data = &r_core_plugin_r2mcp,
 	.version = R2_VERSION,
+#if R2_VERSION_NUMBER >= 50909
 	.abiversion = R2_ABIVERSION
+#endif
 };
 #endif

--- a/src/prompts.c
+++ b/src/prompts.c
@@ -2,6 +2,7 @@
 
 #include "r2mcp.h"
 #include "prompts.h"
+#include "utils.inc.c"
 
 typedef struct {
 	char *name;


### PR DESCRIPTION


- dsltest.c: Fix r_cons_printf API misuse (remove incorrect core->cons arg)
- prompts.c: Include utils.inc.c for r_json_get_str definition
- plugin.c: Add version checks to support both old (5.9.8) and new (6.0+) APIs

**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The build on main (1.5.4, 89e64f461b5430bd8e638c7ed3b37c7be24b30e9) was failing.
I've asked Claude Opus 4.5 to fix it and this is the result.

Tested on my machine and it worked flawlessly.