### PR TITLE
 Add r2frida tools for process introspection, memory operations, search, and symbol lookup

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -511,7 +511,7 @@ static char *tool_list_memory_maps(ServerState *ss, RJson *tool_args) {
 	return tool_cmd_response (r2mcp_cmdf (ss, "%sdm", prefix));
 }
 
-static char *tool_show_headers(ServerState *ss, RJson *tool_args) {
+static char *tool_show_info(ServerState *ss, RJson *tool_args) {
 	(void)tool_args;
 	return tool_cmd_response (r2mcp_cmd (ss, ss->frida_mode ? ":i" : "i;iH"));
 }
@@ -1270,7 +1270,7 @@ ToolSpec tool_specs[] = {
 	{ "list_memory_maps", "Lists memory regions of the process with addresses and permissions", "{\"type\":\"object\",\"properties\":{}}", TOOL_MODE_NORMAL | TOOL_MODE_FRIDA, tool_list_memory_maps },
 	{ "show_function_details", "Displays detailed information about the current function", "{\"type\":\"object\",\"properties\":{}}", TOOL_MODE_NORMAL | TOOL_MODE_RO, tool_show_function_details },
 	{ "get_current_address", "Shows the current position and function name", "{\"type\":\"object\",\"properties\":{}}", TOOL_MODE_NORMAL | TOOL_MODE_RO, tool_get_current_address },
-	{ "show_headers", "Displays binary headers and file information", "{\"type\":\"object\",\"properties\":{}}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO | TOOL_MODE_FRIDA, tool_show_headers },
+	{ "show_info", "Displays information about the binary or target process", "{\"type\":\"object\",\"properties\":{}}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO | TOOL_MODE_FRIDA, tool_show_info },
 	{ "list_symbols", "Shows all symbols (functions, variables, imports) with addresses", "{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"description\":\"Regular expression to filter the results\"}}}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO | TOOL_MODE_FRIDA, tool_list_symbols },
 	{ "list_entrypoints", "Displays program entrypoints, constructors and main function", "{\"type\":\"object\",\"properties\":{}}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO | TOOL_MODE_FRIDA, tool_list_entrypoints },
 	{ "list_methods", "Lists all methods belonging to the specified class", "{\"type\":\"object\",\"properties\":{\"classname\":{\"type\":\"string\",\"description\":\"Name of the class to list methods for\"}},\"required\":[\"classname\"]}", TOOL_MODE_NORMAL | TOOL_MODE_RO | TOOL_MODE_FRIDA, tool_list_methods },


### PR DESCRIPTION
This PR adds new MCP tools that bridge radare2 and r2frida functionality, using a unified prefix pattern (":" in frida mode, "" in normal mode) to avoid code duplication.
* get_pid — get target process ID (dp / :dp)
* list_threads — enumerate process threads (dpt / :dpt)
* dump_registers — show register values with optional thread_id (dr / :dr)
Memory operations
* hexdump — print memory contents at address (px)
* memory_map_here — show memory map at current offset (dm. / :dm.)
* list_heap_allocations — list malloc/heap ranges (dmh / :dmh)
* alloc_memory — allocate memory or strings in target heap (frida-only, :dma / :dmas)
* change_memory_protection — change rwx permissions (frida-only, :dmp)
* search — unified search for strings, hex patterns, wide strings, or numeric values (/ / :/), with type and value_size parameters
* lookup_address — describe what is at a given address (fd / :fd)
* lookup_export — resolve export name to address (iaE / :iaE)
* lookup_symbol — resolve address to symbol name (is. / :is.)