### PR TITLE
Add timeout optional parameter to the analysis tool

### DIFF
--- a/src/r2api.inc.c
+++ b/src/r2api.inc.c
@@ -235,7 +235,7 @@ R_IPI bool r2_open_file(ServerState *ss, const char *filepath) {
 	return true;
 }
 
-R_IPI char *r2_analyze(ServerState *ss, int level) {
+R_IPI char *r2_analyze(ServerState *ss, int level, int timeout_seconds) {
 	if (ss && ss->http_mode) {
 		/* In HTTP mode we won't run local analysis; return empty string. */
 		return strdup ("");
@@ -253,7 +253,13 @@ R_IPI char *r2_analyze(ServerState *ss, int level) {
 		case 4: cmd = "aaaaa"; break;
 		}
 	}
+	if (timeout_seconds >= 0) {
+		r_config_set_i (core->config, "anal.timeout", timeout_seconds);
+	}
 	r2mcp_log_reset (ss);
 	r_core_cmd0 (core, cmd);
+	if (timeout_seconds >= 0) {
+		r_config_set_i (core->config, "anal.timeout", 0);
+	}
 	return r2mcp_log_drain (ss);
 }

--- a/src/r2mcp.h
+++ b/src/r2mcp.h
@@ -13,6 +13,7 @@
 /* Pagination limits for tool responses */
 #define R2MCP_DEFAULT_PAGE_SIZE 1000
 #define R2MCP_MAX_PAGE_SIZE 10000
+#define R2MCP_ANALYZE_TIMEOUT_UNSET (-1)
 
 typedef struct {
 	const char *name;
@@ -101,7 +102,7 @@ void r2mcp_log_pub(ServerState *ss, const char *msg);
 // functionality implemented in r2api.inc.c. These simply forward to the
 // internal static helpers so we keep the original separation.
 bool r2_open_file(ServerState *ss, const char *filepath);
-char *r2_analyze(ServerState *ss, int level);
+char *r2_analyze(ServerState *ss, int level, int timeout_seconds);
 
 // Run a small domain-specific language (DSL) used for testing tools from the
 // command-line. The DSL describes a sequence of tool calls with arguments and

--- a/src/tools.c
+++ b/src/tools.c
@@ -664,7 +664,15 @@ static char *tool_analyze(ServerState *ss, RJson *tool_args) {
 		return jsonrpc_tooltext_response ("Analysis is not available in frida mode. Use list_functions to see exports or run_command with r2frida commands.");
 	}
 	const int level = (int)r_json_get_num (tool_args, "level");
-	char *err = r2_analyze (ss, level);
+	const RJson *timeout_json = r_json_get (tool_args, "timeout_seconds");
+	int timeout_seconds = R2MCP_ANALYZE_TIMEOUT_UNSET;
+	if (timeout_json) {
+		timeout_seconds = (int)r_json_get_num (tool_args, "timeout_seconds");
+		if (timeout_seconds < 0) {
+			timeout_seconds = 0;
+		}
+	}
+	char *err = r2_analyze (ss, level, timeout_seconds);
 	char *cmd_result = r2mcp_cmd (ss, "aflc");
 	char *errstr;
 	if (R_STR_ISNOTEMPTY (err)) {
@@ -672,7 +680,14 @@ static char *tool_analyze(ServerState *ss, RJson *tool_args) {
 	} else {
 		errstr = strdup ("");
 	}
-	char *text = r_str_newf ("Analysis completed with level %d.\nFound %d functions.%s", level, atoi (cmd_result), errstr);
+	bool timed_out = timeout_json && R_STR_ISNOTEMPTY (err) && r_str_casestr (err, "timeout");
+	char *text;
+	if (timed_out) {
+		text = r_str_newf ("Analysis stopped after %d second%s at level %d.\nFound %d functions so far.%s",
+			timeout_seconds, timeout_seconds == 1? "": "s", level, atoi (cmd_result), errstr);
+	} else {
+		text = r_str_newf ("Analysis completed with level %d.\nFound %d functions.%s", level, atoi (cmd_result), errstr);
+	}
 	char *response = jsonrpc_tooltext_response (text);
 	free (err);
 	free (errstr);
@@ -1284,7 +1299,7 @@ ToolSpec tool_specs[] = {
 	{ "set_comment", "Adds a comment at the specified address", "{\"type\":\"object\",\"properties\":{\"address\":{\"type\":\"string\",\"description\":\"Address to put the comment in\"},\"message\":{\"type\":\"string\",\"description\":\"Comment text to use\"}},\"required\":[\"address\",\"message\"]}", TOOL_MODE_NORMAL | TOOL_MODE_HTTP, tool_set_comment },
 	{ "list_strings", "Lists strings from data sections with optional regex filter", "{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"description\":\"Regular expression to filter the results\"},\"cursor\":{\"type\":\"string\",\"description\":\"Cursor for pagination (line number to start from)\"},\"page_size\":{\"type\":\"integer\",\"description\":\"Number of lines per page (default: 1000, max: 10000)\"}}}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO | TOOL_MODE_FRIDA, tool_list_strings },
 	{ "list_all_strings", "Scans the entire binary for strings with optional regex filter", "{\"type\":\"object\",\"properties\":{\"filter\":{\"type\":\"string\",\"description\":\"Regular expression to filter the results\"},\"cursor\":{\"type\":\"string\",\"description\":\"Cursor for pagination (line number to start from)\"},\"page_size\":{\"type\":\"integer\",\"description\":\"Number of lines per page (default: 1000, max: 10000)\"}}}", TOOL_MODE_NORMAL | TOOL_MODE_RO, tool_list_all_strings },
-	{ "analyze", "Runs binary analysis with optional depth level", "{\"type\":\"object\",\"properties\":{\"level\":{\"type\":\"number\",\"description\":\"Analysis level (0-4, higher is more thorough)\"}},\"required\":[]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_FRIDA, tool_analyze },
+	{ "analyze", "Runs binary analysis with optional depth level", "{\"type\":\"object\",\"properties\":{\"level\":{\"type\":\"number\",\"description\":\"Analysis level (0-4, higher is more thorough)\"},\"timeout_seconds\":{\"type\":\"integer\",\"description\":\"Optional maximum analysis time in seconds for this call only. Use 0 to disable the timeout.\"}},\"required\":[]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_FRIDA, tool_analyze },
 	{ "xrefs_to", "Finds all code references to the specified address", "{\"type\":\"object\",\"properties\":{\"address\":{\"type\":\"string\",\"description\":\"Address to check for cross-references\"}},\"required\":[\"address\"]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO, tool_xrefs_to },
 	{ "decompile_function", "Show C-like pseudocode of the function in the given address. <think>Use this to inspect the code in a function, do not run multiple times in the same offset</think>", "{\"type\":\"object\",\"properties\":{\"address\":{\"type\":\"string\",\"description\":\"Address of the function to decompile\"},\"cursor\":{\"type\":\"string\",\"description\":\"Cursor for pagination (line number to start from)\"},\"page_size\":{\"type\":\"integer\",\"description\":\"Number of lines per page (default: 1000, max: 10000)\"}},\"required\":[\"address\"]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO, tool_decompile_function },
 	{ "list_files", "Lists files in the specified path using radare2's ls -q command. Files ending with / are directories, otherwise they are files.", "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Path to list files from\"}},\"required\":[\"path\"]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_RO, tool_list_files },


### PR DESCRIPTION
Required r2-6.1.2 because anal.timeout wasnt reliable before