### PR TITLE
Harden supervisor responses against raw r2cmd execution

### DIFF
--- a/src/r2mcp.c
+++ b/src/r2mcp.c
@@ -400,11 +400,8 @@ static char *handle_mcp_request(ServerState *ss, const char *method, RJson *para
 					}
 					const char *r2cmd = r_json_get_str (rj, "r2cmd");
 					if (r2cmd) {
-						char *cmd_out = r2mcp_cmd (ss, r2cmd);
-						char *res = jsonrpc_tooltext_response (cmd_out? cmd_out: "");
-						free (cmd_out);
 						r_json_free (rj);
-						result = res;
+						return jsonrpc_error_response (-32000, "Supervisor responses with 'r2cmd' are not allowed. Return 'tool' + 'arguments' instead.", id, NULL);
 					} else {
 						const char *new_tool = r_json_get_str (rj, "tool");
 						const RJson *new_args = r_json_get (rj, "arguments");

--- a/src/tools.c
+++ b/src/tools.c
@@ -1146,20 +1146,9 @@ static char *check_supervisor_permission(ServerState *ss, const char *tool_name,
 	}
 	const char *r2cmd = r_json_get_str (*parsed_json_out, "r2cmd");
 	if (r2cmd) {
-		char *cmd_out = r2mcp_cmd (ss, r2cmd);
-		char *res = jsonrpc_tooltext_response (cmd_out? cmd_out: "");
-		free (cmd_out);
-		if (!strcmp (tool_name, "open_file")) {
-			const char *filepath = r_json_get_str (tool_args, "file_path");
-			if (filepath) {
-				free (ss->rstate.current_file);
-				ss->rstate.current_file = strdup (filepath);
-				ss->rstate.file_opened = true;
-			}
-		}
 		r_json_free (*parsed_json_out);
 		*parsed_json_out = NULL;
-		return res;
+		return jsonrpc_error_response (-32000, "Supervisor responses with 'r2cmd' are not allowed. Return 'tool' + 'arguments' instead.", NULL, NULL);
 	}
 	const char *new_tool = r_json_get_str (*parsed_json_out, "tool");
 	if (new_tool && strcmp (new_tool, tool_name)) {


### PR DESCRIPTION
### Motivation
- The supervisor service could return an `r2cmd` field which the server executed directly via `r2mcp_cmd`, bypassing tool allow/deny lists and runtime flags (e.g. `enable_run_command_tool`) and enabling arbitrary radare2 command execution.
- The change blocks this bypass so supervisor-driven actions must use `tool` + `arguments` and go through the normal tool dispatch and gating logic.

### Description
- In `src/r2mcp.c` reject supervisor HTTP responses that include an `r2cmd` field by returning a JSON-RPC error instead of calling `r2mcp_cmd` directly.
- In `src/tools.c` inside `check_supervisor_permission` reject supervisor responses containing `r2cmd` and return a JSON-RPC error instead of executing the command and mutating `ss->rstate`.
- Preserve existing supervisor delegation behavior when the response contains `tool` and `arguments`, which continue to be handled by `handle_call_tool` and therefore subject to `tools_is_tool_allowed` and other runtime checks.
- The changes are intentionally minimal to remove the privileged raw-command path while keeping the authorized supervisor workflow intact.

### Testing
- Attempted a local build with `make -C src -j`, but compilation could not complete in this environment due to missing radare2 development dependencies (`r_core.h` / `r_core.pc`), so no runtime binary tests were executed.
- Verified by code inspection and repository searches that both supervisor-response execution paths that previously accepted `r2cmd` were updated to return an error instead of executing the command.
- No automated unit tests were present for this case; the fix is a small control-flow hardening change to remove the direct execution vector.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22b6354d083319f611b16009a898d)