### PR TITLE
tools: enforce read-only mode precedence over sessions/http

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -81,6 +81,9 @@ static bool tool_allowed_by_runtime_flags(const ServerState *ss, const char *nam
 }
 
 static inline ToolMode current_mode(const ServerState *ss) {
+	if (ss->readonly_mode) {
+		return TOOL_MODE_RO;
+	}
 	ToolMode mode = 0;
 	if (ss->http_mode) {
 		mode |= TOOL_MODE_HTTP;
@@ -90,9 +93,6 @@ static inline ToolMode current_mode(const ServerState *ss) {
 	}
 	if (ss->use_sessions) {
 		mode |= TOOL_MODE_SESSIONS;
-	}
-	if (ss->readonly_mode) {
-		mode |= TOOL_MODE_RO;
 	}
 	if (ss->minimode) {
 		mode |= TOOL_MODE_MINI;


### PR DESCRIPTION
### Motivation
- Prevent a read-only bypass where enabling sessions (`-L`) allowed `open_session` to set `http_mode` and subsequently re-enable HTTP-mode tools despite `readonly_mode` (`-R`) being set.

### Description
- Make `current_mode()` in `src/tools.c` return `TOOL_MODE_RO` immediately when `ss->readonly_mode` is true so read-only mode takes strict precedence over sessions and HTTP modes, without changing tool registry or public APIs.

### Testing
- Attempted to build with `make -C src -j`, which failed in this environment due to missing radare2 development headers/pkg-config metadata (`r_core`), so no binary-level tests were produced; the change is minimal and verified via the source diff and local commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2269ae2b083318193d926c3ef0223)