### PR TITLE
Fix sandbox escape via non-canonical paths

### DIFF
--- a/src/r2api.inc.c
+++ b/src/r2api.inc.c
@@ -129,7 +129,7 @@ static bool path_contains_parent_ref(const char *p) {
 	return p && strstr (p, "/../") != NULL;
 }
 
-static bool path_is_within_sandbox(const char *p, const char *sb) {
+static bool canonical_path_is_within_sandbox(const char *p, const char *sb) {
 	if (R_STR_ISEMPTY (sb)) {
 		return true;
 	}
@@ -142,10 +142,31 @@ static bool path_is_within_sandbox(const char *p, const char *sb) {
 		return false;
 	}
 	if (plen == slen) {
-		return true; // exact match
+		return true;
 	}
 	// ensure boundary: next char must be '/'
 	return p[slen] == '/';
+}
+
+static bool path_is_within_sandbox(const char *p, const char *sb) {
+	if (R_STR_ISEMPTY (sb)) {
+		return true;
+	}
+	char *rp = realpath (p, NULL);
+	if (!rp) {
+		R_LOG_ERROR ("Access denied: unable to resolve path");
+		return false;
+	}
+	char *rsb = realpath (sb, NULL);
+	if (!rsb) {
+		R_LOG_ERROR ("Access denied: unable to resolve sandbox path");
+		free (rp);
+		return false;
+	}
+	bool ret = canonical_path_is_within_sandbox (rp, rsb);
+	free (rp);
+	free (rsb);
+	return ret;
 }
 
 R_IPI bool r2_open_file(ServerState *ss, const char *filepath) {


### PR DESCRIPTION
### Motivation
- The sandbox checks previously relied on lexical prefix checks and a literal "/../" substring test which can be bypassed by non-canonical paths or symlink traversal.  
- This allowed requests such as `/sandbox/..` (which does not contain `/../`) or sandboxed symlinks to escape the intended root.  
- The change strengthens the sandbox enforcement by validating canonical paths before applying the boundary check.

### Description
- Canonicalize both the requested path and the sandbox root with `realpath` and apply the existing prefix/boundary logic to the resolved paths in `src/r2api.inc.c`.  
- Introduced `canonical_path_is_within_sandbox` to preserve the original prefix+boundary semantics and kept it separate from the `realpath`-using wrapper.  
- `path_is_within_sandbox` now fails (returns false) if either `realpath` call cannot resolve the target or sandbox, with an `R_LOG_ERROR` message to avoid allowing unverifiable paths.  
- Existing checks in `r2_open_file` (absolute path and `/../` substring test) are left intact and now rely on the improved `path_is_within_sandbox` for robust sandbox enforcement.

### Testing
- Attempted to build with `make -C src -j`, but the build could not complete in this environment because `r_core` development headers/pkg-config (`r_core.pc`) are not available, so a full compile/run validation could not be performed (no binary produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22b5eb3f883319b477af7ccfccb57)