### PR TITLE
Harden r2_open_file: prevent sandbox bypass via URI schemes

### DIFF
--- a/src/r2api.inc.c
+++ b/src/r2api.inc.c
@@ -157,18 +157,26 @@ R_IPI bool r2_open_file(ServerState *ss, const char *filepath) {
 		return false;
 	}
 	bool is_uri = strstr (filepath, "://") != NULL;
-	// Filesystem security checks only apply to local paths, not URI schemes
-	if (!is_uri) {
-		if (!r_file_is_abspath (filepath)) {
+	const char *local_path = filepath;
+	if (is_uri) {
+		if (r_str_startswith (filepath, "file://")) {
+			local_path = filepath + strlen ("file://");
+		} else if (ss->sandbox && *ss->sandbox) {
+			R_LOG_ERROR ("URI schemes are not allowed in sandbox mode");
+			return false;
+		}
+	}
+	if (local_path != filepath || !is_uri) {
+		if (!r_file_is_abspath (local_path)) {
 			R_LOG_ERROR ("Relative paths are not allowed. Use an absolute path");
 			return false;
 		}
-		if (path_contains_parent_ref (filepath)) {
+		if (path_contains_parent_ref (local_path)) {
 			R_LOG_ERROR ("Path traversal is not allowed (contains '/../')");
 			return false;
 		}
 		if (ss->sandbox && *ss->sandbox) {
-			if (!path_is_within_sandbox (filepath, ss->sandbox)) {
+			if (!path_is_within_sandbox (local_path, ss->sandbox)) {
 				R_LOG_ERROR ("Access denied: path is outside of the sandbox");
 				return false;
 			}


### PR DESCRIPTION
### Motivation
- A prior change skipped filesystem validation for any path containing `://`, which allowed clients to bypass `-s` sandbox checks using `file://` or other URI schemes and escape the sandbox.
- The change restores safe behavior by ensuring local-path validation still applies to `file://` URIs and by blocking non-file schemes when sandboxing is enabled.

### Description
- Decode `file://` URIs into a `local_path` and run existing checks (`r_file_is_abspath`, `path_contains_parent_ref`, `path_is_within_sandbox`) against that decoded path.
- Reject non-`file://` URI schemes when `ss->sandbox` is set by returning an error and denying access.
- Introduce a `local_path` variable and switch the security checks to operate on it so behavior for local absolute paths is unchanged.
- Keep existing behavior for HTTP mode and FRIDA detection intact; this is a minimal, targeted fix limited to `r2_open_file`.

### Testing
- Attempted to build with `make -C src -j`, but the build failed in this environment due to missing radare2 development headers and `r_core.pc` in `pkg-config`, so no binary was produced.
- Attempted `src/r2mcp -h` and `src/r2mcp -t`, but the binary was unavailable because the build did not complete in this environment.
- No automated unit tests were added or available to run in this environment; code inspection verifies that `file://` paths are now validated and non-`file://` URIs are rejected when sandboxing is active.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22641bab88331afc7174eb8c6d958)