### PR TITLE
Fix build errors with radare2 5.9.8

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,7 @@ COMMON_SRC += prompts.c
 COMMON_SRC += jsonrpc.c
 COMMON_SRC += validation.c
 COMMON_SRC += sessions.c
+COMMON_SRC += compat.c
 BIN_SRC = main.c $(COMMON_SRC)
 PLUGIN_SRC = plugin.c $(COMMON_SRC)
 INC = utils.inc.c

--- a/src/compat.c
+++ b/src/compat.c
@@ -1,0 +1,35 @@
+/* r2mcp - MIT - Copyright 2025 - pancake */
+
+#if R2_VERSION_NUMBER < 50909
+#include <r_core.h>
+#include <r_util/r_json.h>
+
+st64 r_json_get_num(const RJson *json, const char *key) {
+	R_RETURN_VAL_IF_FAIL (json && key, 0);
+	const RJson *field = r_json_get (json, key);
+	if (field) {
+		switch (field->type) {
+		case R_JSON_STRING:
+			return r_num_get (NULL, field->str_value);
+		case R_JSON_INTEGER:
+			return field->num.s_value;
+		case R_JSON_BOOLEAN:
+			return field->num.u_value;
+		case R_JSON_DOUBLE:
+			return (int)field->num.dbl_value;
+		default:
+			break;
+		}
+	}
+	return 0;
+}
+
+const char *r_json_get_str(const RJson *json, const char *key) {
+	R_RETURN_VAL_IF_FAIL (json && key, NULL);
+	const RJson *field = r_json_get (json, key);
+	if (!field || field->type != R_JSON_STRING) {
+		return NULL;
+	}
+	return field->str_value;
+}
+#endif

--- a/src/prompts.c
+++ b/src/prompts.c
@@ -3,6 +3,11 @@
 #include "r2mcp.h"
 #include "prompts.h"
 
+#if R2_VERSION_NUMBER < 50909
+st64 r_json_get_num(const RJson *json, const char *key);
+const char *r_json_get_str(const RJson *json, const char *key);
+#endif
+
 typedef struct {
 	char *name;
 	char *desc;

--- a/src/tools.c
+++ b/src/tools.c
@@ -1220,9 +1220,7 @@ static char *tool_sql(ServerState *ss, RJson *tool_args) {
 		return jsonrpc_error_file_required ();
 	}
 	cmd = r_str_newf ("r2vsql %s", query);
-	R_CRITICAL_ENTER (core);
-	res = r_core_call_str_at (core, core->addr, cmd);
-	R_CRITICAL_LEAVE (core);
+	res = r2mcp_cmd (ss, cmd);
 	free (cmd);
 	if (!res) {
 		res = strdup ("Error: r2vsql command returned NULL");

--- a/src/validation.c
+++ b/src/validation.c
@@ -3,6 +3,11 @@
 #include "validation.h"
 #include "jsonrpc.h"
 
+#if R2_VERSION_NUMBER < 50909
+st64 r_json_get_num(const RJson *json, const char *key);
+const char *r_json_get_str(const RJson *json, const char *key);
+#endif
+
 /* Check if a parameter exists and is a string */
 ValidationResult validate_required_string(RJson *args, const char *param_name) {
 	const RJson *field = r_json_get (args, param_name);


### PR DESCRIPTION
## Summary
- Replace outdated `r_core_call_str_at()` API call with `r2mcp_cmd()` in tools.c
- Add compat.c with non-static compatibility functions for r_json_get_str/r_json_get_num
- Add function declarations to prompts.c and validation.c for older radare2 versions
- Update Makefile to include compat.c in build

## Problem
These fixes resolve build failures when using radare2 5.9.8 where:
1. `core->addr` member no longer exists in RCore struct
2. `r_json_get_str`/`r_json_get_num` need to be available across compilation units

## Changes
- **5 files changed**: 47 insertions, 3 deletions
- **New file**: `src/compat.c` with compatibility functions
- **Fixed**: Outdated API calls and missing cross-compilation unit function availability

## Test plan
- ✅ Build succeeds with radare2 5.9.8
- ✅ Manual installation works correctly
- ✅ `r2pm -r r2mcp -h` displays help properly
- ✅ Prompts are installed and accessible

Generated with [Devin](https://devin.ai)