### PR TITLE
Add arch, bits and cpu arguments

### DIFF
--- a/src/r2api.inc.c
+++ b/src/r2api.inc.c
@@ -137,7 +137,7 @@ char *r2mcp_cmdf(ServerState *ss, const char *fmt, ...) {
 	return res;
 }
 
-R_IPI bool r2_open_file(ServerState *ss, const char *filepath, ut64 baddr) {
+R_IPI bool r2_open_file(ServerState *ss, const char *filepath, ut64 baddr, const char *arch, int bits, const char *cpu) {
 	R_LOG_INFO ("Attempting to open file: %s\n", filepath);
 
 	// Security checks common to both local and HTTP modes
@@ -178,6 +178,16 @@ R_IPI bool r2_open_file(ServerState *ss, const char *filepath, ut64 baddr) {
 	}
 	r_config_set_b (core->config, "cfg.sandbox", false);
 
+	if (R_STR_ISNOTEMPTY (arch)) {
+		r_config_set (core->config, "asm.arch", arch);
+	}
+	if (bits > 0) {
+		r_config_set_i (core->config, "asm.bits", bits);
+	}
+	if (R_STR_ISNOTEMPTY (cpu)) {
+		r_config_set (core->config, "asm.cpu", cpu);
+	}
+
 	ss->frida_mode = strstr (filepath, "frida://") != NULL;
 	if (!ss->frida_mode) {
 		r_core_cmd0 (core, "e bin.relocs.apply=true");
@@ -198,7 +208,14 @@ R_IPI bool r2_open_file(ServerState *ss, const char *filepath, ut64 baddr) {
 	RBinFile *bi = core->bin->cur;
 	bool have_bin_info = bi && bi->bo && bi->bo->info && bi->bo->info->type;
 	if (!have_bin_info && baddr != UT64_MAX) {
-		R_LOG_WARN ("Don't use baddr on unknown files. Consider mapping the file instead.");
+		ut64 fsize = r_io_desc_size (file);
+		if (fsize > 0) {
+			r_io_map_add (core->io, file->fd, R_PERM_RX, 0, baddr, fsize);
+			r_core_seek (core, baddr, true);
+			R_LOG_INFO ("Mapped raw file at 0x%" PFMT64x " (size 0x%" PFMT64x ")", baddr, fsize);
+		} else {
+			R_LOG_WARN ("Don't use baddr on unknown files. Consider mapping the file instead.");
+		}
 	}
 	free (ss->rstate->current_file);
 	ss->rstate->current_file = strdup (filepath);

--- a/src/r2mcp.h
+++ b/src/r2mcp.h
@@ -168,7 +168,7 @@ const char *r2mcp_effective_sandbox_grain(const ServerState *ss);
 // Additional public wrappers exposed so other modules (eg. tools.c) can use
 // functionality implemented in r2api.inc.c. These simply forward to the
 // internal static helpers so we keep the original separation.
-bool r2_open_file(ServerState *ss, const char *filepath, ut64 baddr);
+bool r2_open_file(ServerState *ss, const char *filepath, ut64 baddr, const char *arch, int bits, const char *cpu);
 char *r2_analyze(ServerState *ss, int level, int timeout_seconds);
 int r2_function_count(ServerState *ss);
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -1584,6 +1584,13 @@ char *tools_call(ServerState *ss, const char *tool_name, RJson *tool_args) {
 			free (baddr_error);
 			goto cleanup;
 		}
+		// Optional explicit arch/bits/cpu, for raw/headerless binaries (eg.
+		// MCU firmware .bin dumps) that cannot be autodetected and would
+		// otherwise disassemble with the host's default arch.
+		const char *arch = r_json_get_str (tool_args, "arch");
+		const char *cpu = r_json_get_str (tool_args, "cpu");
+		int bits = 0;
+		(void)rjson_get_int_param (tool_args, "bits", &bits);
 
 		char *filteredpath = strdup (filepath);
 		r_str_replace_ch (filteredpath, '`', 0, true);
@@ -1616,7 +1623,7 @@ char *tools_call(ServerState *ss, const char *tool_name, RJson *tool_args) {
 			char *close_res = tool_close_file (ss, &nil);
 			free (close_res);
 		}
-		bool success = r2_open_file (ss, filteredpath, baddr);
+		bool success = r2_open_file (ss, filteredpath, baddr, arch, bits, cpu);
 		free (filteredpath);
 		if (success && previous_file) {
 			char *text = r_str_newf ("Closed previously opened file: %s\nFile opened successfully.", previous_file);
@@ -1707,7 +1714,7 @@ cleanup:
 #define TOOL_SCHEMA_SCRIPT_FILE_PAGE "{\"type\":\"object\",\"properties\":{\"file_path\":{\"type\":\"string\",\"description\":\"Absolute path to the radare2 script file to execute\"}," TOOL_SCHEMA_PAGE_PROPS "},\"required\":[\"file_path\"]}"
 
 ToolSpec tool_specs[] = {
-	{ "open_file", "Opens a binary file with radare2 for analysis <think>Call this tool before any other one from r2mcp. Use an absolute file_path</think>", "{\"type\":\"object\",\"properties\":{\"file_path\":{\"type\":\"string\",\"description\":\"Path to the file to open\"},\"baddr\":{\"type\":\"string\",\"description\":\"Optional base address for PIE binaries, same as radare2 -B (for example 0x400000)\"}},\"required\":[\"file_path\"]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI, NULL },
+	{ "open_file", "Opens a binary file with radare2 for analysis <think>Call this tool before any other one from r2mcp. Use an absolute file_path</think>", "{\"type\":\"object\",\"properties\":{\"file_path\":{\"type\":\"string\",\"description\":\"Path to the file to open\"},\"baddr\":{\"type\":\"string\",\"description\":\"Optional base address for PIE binaries, same as radare2 -B / -m (for example 0x400000). For raw/headerless files (no ELF/PE magic), this now also creates an explicit io map so the file's content actually appears at this address, matching radare2 CLI's -m behavior\"},\"arch\":{\"type\":\"string\",\"description\":\"Optional asm.arch override (eg. 'arm'), same as radare2 -a. Needed for raw/headerless binaries which cannot be autodetected and would otherwise default to the host arch\"},\"bits\":{\"type\":\"string\",\"description\":\"Optional asm.bits override (eg. 16 for ARM Thumb), same as radare2 -b\"},\"cpu\":{\"type\":\"string\",\"description\":\"Optional asm.cpu override (eg. 'cortex'), same as radare2 -k/-e asm.cpu\"}},\"required\":[\"file_path\"]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI, NULL },
 	{ "run_javascript", "Executes JavaScript code using radare2's qjs runtime", "{\"type\":\"object\",\"properties\":{\"script\":{\"type\":\"string\",\"description\":\"The JavaScript code to execute\"}},\"required\":[\"script\"]}", TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_EXEC, tool_run_javascript },
 	{ "run_frida_script", "Executes Frida JavaScript code", "{\"type\":\"object\",\"properties\":{\"script\":{\"type\":\"string\",\"description\":\"The script code to execute\"}},\"required\":[\"script\"]}", TOOL_MODE_FRIDA | TOOL_MODE_EXEC, tool_run_frida_script },
 	{ "run_command", "Executes a raw radare2 command directly", TOOL_SCHEMA_COMMAND_PAGE, TOOL_MODE_NORMAL | TOOL_MODE_MINI | TOOL_MODE_HTTP | TOOL_MODE_EXEC, tool_run_command },


### PR DESCRIPTION
**Description**

When working on raw/headerless bin file the tool can't detect the type of the file. So it is using the host's arch and always mapped to 0x0.

For example, STM32 target could be opened and processed properly using `open_file file_path=... baddr=0x08000000 arch=arm bits=16 cpu=cortex`