### PR TITLE
fix for issue #71 tool_close_file cleanup improvement

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -598,11 +598,18 @@ static char *tool_close_file(ServerState *ss, RJson *tool_args) {
 		return jsonrpc_tooltext_response ("In r2pipe mode we won't close the file.");
 	}
 	if (ss->rstate->core) {
+		RCore *core = ss->rstate->core;
 		bool was_sandboxed = r_sandbox_enable (false);
 		if (was_sandboxed) {
 			r_sandbox_disable (true);
 		}
 		free (r2mcp_cmd (ss, "o-*"));
+		if (core->anal) {
+			r_anal_purge (core->anal);
+		}
+		if (core->flags) {
+			r_flag_unset_all (core->flags);
+		}
 		if (was_sandboxed) {
 			r_sandbox_disable (false);
 		}

--- a/src/tools.c
+++ b/src/tools.c
@@ -495,12 +495,8 @@ static char *tool_close_file(ServerState *ss, RJson *tool_args) {
 			r_sandbox_disable (true);
 		}
 		free (r2mcp_cmd (ss, "o-*"));
-		if (core->anal) {
-			r_anal_purge (core->anal);
-		}
-		if (core->flags) {
-			r_flag_unset_all (core->flags);
-		}
+		r_anal_purge (core->anal);
+		r_flag_unset_all (core->flags);
 		if (was_sandboxed) {
 			r_sandbox_disable (false);
 		}


### PR DESCRIPTION
closing a file and opening other file was keeping some metadata of previous binary.