### PR TITLE
fix for issue #71 metadata cleanup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,9 @@ r_deps = {
   'r_util': ['r_util', 'libr_util'],
   'r_cons': ['r_cons', 'libr_cons'],
   'r_config': ['r_config', 'libr_config'],
-  'r_socket': ['r_socket', 'libr_socket']
+  'r_socket': ['r_socket', 'libr_socket'],
+  'r_anal': ['r_anal', 'libr_anal'],
+  'r_flag': ['r_flag', 'libr_flag']
 }
 
 foreach dep_name, lib_names : r_deps
@@ -162,7 +164,7 @@ endif
 executable(
   'r2mcp',
   srcs,
-  dependencies: [r_core_dep, r_socket_dep, r_util_dep, r_cons_dep, r_config_dep],
+  dependencies: [r_core_dep, r_socket_dep, r_util_dep, r_cons_dep, r_config_dep, r_anal_dep, r_flag_dep],
   c_args: c_args,
   link_args: link_args,
   install: true,
@@ -171,7 +173,7 @@ executable(
 plugin_lib = shared_library(
   'core_r2mcp',
   plugin_srcs,
-  dependencies: [r_core_dep, r_socket_dep, r_util_dep, r_cons_dep, r_config_dep],
+  dependencies: [r_core_dep, r_socket_dep, r_util_dep, r_cons_dep, r_config_dep, r_anal_dep, r_flag_dep],
   c_args: c_args,
   link_args: link_args,
   install: false,

--- a/src/tools.c
+++ b/src/tools.c
@@ -598,11 +598,18 @@ static char *tool_close_file(ServerState *ss, RJson *tool_args) {
 		return jsonrpc_tooltext_response ("In r2pipe mode we won't close the file.");
 	}
 	if (ss->rstate->core) {
+		RCore *core = ss->rstate->core;
 		bool was_sandboxed = r_sandbox_enable (false);
 		if (was_sandboxed) {
 			r_sandbox_disable (true);
 		}
 		free (r2mcp_cmd (ss, "o-*"));
+		if (core->anal) {
+			r_anal_purge (core->anal);
+		}
+		if (core->flags) {
+			r_flag_unset_all (core->flags);
+		}
 		if (was_sandboxed) {
 			r_sandbox_disable (false);
 		}

--- a/src/tools.c
+++ b/src/tools.c
@@ -495,12 +495,8 @@ static char *tool_close_file(ServerState *ss, RJson *tool_args) {
 			r_sandbox_disable (true);
 		}
 		free (r2mcp_cmd (ss, "o-*"));
-		if (core->anal) {
-			r_anal_purge (core->anal);
-		}
-		if (core->flags) {
-			r_flag_unset_all (core->flags);
-		}
+		r_anal_purge (core->anal);
+		r_flag_unset_all (core->flags);
 		if (was_sandboxed) {
 			r_sandbox_disable (false);
 		}


### PR DESCRIPTION
Changing the cleanup to "C-*" would only clean code comments,  so it's needed to purge the analysis object and unset flags.