### PR TITLE
Configurable hidden paths

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -40,7 +40,6 @@ void r2mcp_help(void) {
 		" -A         generate and require a random HTTP Bearer auth token\n"
 		" -C [mode]  content mode: text (default), json, structured, both\n"
 		" -D         deny access to paths containing hidden components\n"
-		" --deny-hidden-paths same as -D\n"
 		" -a [token] require HTTP Authorization: Bearer [token] (use 'random' to generate)\n"
 		" -c [cmd]   run those commands before entering the mcp loop\n"
 		" -d [pdc]   select a different decompiler (pdc by default)\n"
@@ -119,18 +118,6 @@ int r2mcp_main(int argc, const char **argv) {
 	const char *dsl_tests = NULL;
 	RList *disabled_tools = NULL;
 	RGetopt opt;
-	int i;
-	for (i = 1; i < argc; i++) {
-		if (!strcmp (argv[i], "--deny-hidden-paths")) {
-			int j;
-			deny_hidden_paths = true;
-			for (j = i; j + 1 < argc; j++) {
-				argv[j] = argv[j + 1];
-			}
-			argc--;
-			i--;
-		}
-	}
 	r_getopt_init (&opt, argc, argv, "AC:a:DE:H:hmvtpd:nc:u:g:l:s:rite:RT:S:P:NLX:");
 	int c;
 	while ((c = r_getopt_next (&opt)) != -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,8 @@ void r2mcp_help(void) {
 		"Usage: r2mcp [-flags]\n"
 		" -A         generate and require a random HTTP Bearer auth token\n"
 		" -C [mode]  content mode: text (default), json, structured, both\n"
+		" -D         deny access to paths containing hidden components\n"
+		" --deny-hidden-paths same as -D\n"
 		" -a [token] require HTTP Authorization: Bearer [token] (use 'random' to generate)\n"
 		" -c [cmd]   run those commands before entering the mcp loop\n"
 		" -d [pdc]   select a different decompiler (pdc by default)\n"
@@ -87,6 +89,7 @@ int r2mcp_main(int argc, const char **argv) {
 	bool readonly_mode = false;
 	bool list_tools = false;
 	bool show_help = false;
+	bool deny_hidden_paths = false;
 	int exit_status = 0;
 	char *sandbox_grain_msg = NULL;
 	RList *cmds = r_list_newf (free);
@@ -116,7 +119,19 @@ int r2mcp_main(int argc, const char **argv) {
 	const char *dsl_tests = NULL;
 	RList *disabled_tools = NULL;
 	RGetopt opt;
-	r_getopt_init (&opt, argc, argv, "AC:a:E:H:hmvtpd:nc:u:g:l:s:rite:RT:S:P:NLX:");
+	int i;
+	for (i = 1; i < argc; i++) {
+		if (!strcmp (argv[i], "--deny-hidden-paths")) {
+			int j;
+			deny_hidden_paths = true;
+			for (j = i; j + 1 < argc; j++) {
+				argv[j] = argv[j + 1];
+			}
+			argc--;
+			i--;
+		}
+	}
+	r_getopt_init (&opt, argc, argv, "AC:a:DE:H:hmvtpd:nc:u:g:l:s:rite:RT:S:P:NLX:");
 	int c;
 	while ((c = r_getopt_next (&opt)) != -1) {
 		switch (c) {
@@ -128,6 +143,9 @@ int r2mcp_main(int argc, const char **argv) {
 				R_LOG_ERROR ("Failed to generate HTTP bearer token");
 				return 1;
 			}
+			break;
+		case 'D':
+			deny_hidden_paths = true;
 			break;
 		case 'C':
 			content_mode = r2mcp_content_mode_from_string (opt.arg);
@@ -354,6 +372,7 @@ int r2mcp_main(int argc, const char **argv) {
 		.auth_token = auth_token,
 		.auth_token_generated = auth_token_generated,
 		.sandbox = sandbox,
+		.deny_hidden_paths = deny_hidden_paths,
 		.sandbox_grain = sandbox_grain,
 		.logfile = logfile,
 		.prompts_dir = prompts_dir,

--- a/src/path.inc.c
+++ b/src/path.inc.c
@@ -105,7 +105,7 @@ static const char *r2mcp_sandbox_check(ServerState *ss, const char *path) {
 	if (r2mcp_path_contains_parent_ref (path)) {
 		return "Path traversal is not allowed (contains '..' path segments)";
 	}
-	if (*path == '.' || strstr (path, "/.") || strstr (path, "\\.")) {
+	if (ss->deny_hidden_paths && (*path == '.' || strstr (path, "/.") || strstr (path, "\\."))) {
 		return "Access denied: hidden paths are not allowed";
 	}
 	if (ss->sandbox && *ss->sandbox && !r2mcp_path_is_within_sandbox (path, ss->sandbox)) {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -63,6 +63,7 @@ static void r2mcp_config_init(RCore *core) {
 	r2mcp_cfg_set_b (core, "r2mcp.prompts", true, "load r2mcp prompts");
 	r2mcp_cfg_set_s (core, "r2mcp.prompts.dir", "", "colon-separated prompt directories");
 	r2mcp_cfg_set_s (core, "r2mcp.sandbox", "", "restrict open_file to this sandbox directory");
+	r2mcp_cfg_set_b (core, "r2mcp.deny_hidden_paths", false, "deny access to paths containing hidden components");
 	r2mcp_cfg_set_s (core, "r2mcp.sandbox.grain", "", "radare2 sandbox grain mask (disk,files,exec,socket,network,environ,all,none)");
 	node = r2mcp_cfg_set_s (core, "r2mcp.content", "text", "tool response content mode");
 	r_config_node_add_option (node, "text");
@@ -183,6 +184,7 @@ static ServerState *r2mcp_state_new_from_config(RCore *core) {
 	}
 #endif
 	ss->sandbox = r2mcp_cfg_get_dup (core, "r2mcp.sandbox");
+	ss->deny_hidden_paths = r_config_get_b (core->config, "r2mcp.deny_hidden_paths");
 	ss->sandbox_grain = r2mcp_cfg_get_dup (core, "r2mcp.sandbox.grain");
 	ss->logfile = r2mcp_cfg_get_dup (core, "r2mcp.logfile");
 	if (ss->logfile) {
@@ -377,6 +379,7 @@ static void r2mcp_print_config(RCore *core) {
 		"r2mcp.prompts\n"
 		"r2mcp.prompts.dir\n"
 		"r2mcp.sandbox\n"
+		"r2mcp.deny_hidden_paths\n"
 		"r2mcp.sandbox.grain\n"
 		"r2mcp.content\n"
 		"r2mcp.enabled\n"

--- a/src/r2mcp.h
+++ b/src/r2mcp.h
@@ -107,6 +107,8 @@ typedef struct {
 	bool auth_token_generated;
 	/* Optional sandbox path. When set, only allow opening files under this dir */
 	char *sandbox;
+	/* When true, reject paths containing hidden components */
+	bool deny_hidden_paths;
 	/* Optional radare2 sandbox grain mask; NULL selects a mode-aware default */
 	char *sandbox_grain;
 	/* Optional path to append debug logs when set via -l */

--- a/test2.sh
+++ b/test2.sh
@@ -676,8 +676,7 @@ run_hidden_path_regression() {
 	local hidden_dir="$TMPDIR/.hidden"
 	local req="$TMPDIR/hidden-path.req"
 	local resp="$TMPDIR/hidden-path.resp"
-	local deny_short_resp="$TMPDIR/hidden-path-deny-short.resp"
-	local deny_long_resp="$TMPDIR/hidden-path-deny-long.resp"
+	local deny_resp="$TMPDIR/hidden-path-deny.resp"
 	mkdir -p "$hidden_dir"
 	cp /bin/ls "$hidden_dir/ls"
 	: > "$req"
@@ -686,23 +685,17 @@ run_hidden_path_regression() {
 	append_notification "$req" notifications/initialized '{}'
 	append_tool_call "$req" 2 open_file "$(jq -cn --arg file "$hidden_dir/ls" '{file_path:$file}')"
 	run_session "$req" "$resp"
-	run_session "$req" "$deny_short_resp" -D
-	run_session "$req" "$deny_long_resp" --deny-hidden-paths
+	run_session "$req" "$deny_resp" -D
 
 	local open_hidden
-	local deny_short
-	local deny_long
+	local deny_hidden
 	open_hidden=$(response_by_id "$resp" 2)
-	deny_short=$(response_by_id "$deny_short_resp" 2)
-	deny_long=$(response_by_id "$deny_long_resp" 2)
+	deny_hidden=$(response_by_id "$deny_resp" 2)
 	printf '%s\n' "$open_hidden" | jq -e '.result.content[0].text | contains("File opened")' >/dev/null 2>&1 || {
 		fail "open_file should allow files under hidden directories, got $open_hidden"
 	}
-	printf '%s\n' "$deny_short" | jq -e '.result.content[0].text == "Failed to open file."' >/dev/null 2>&1 || {
-		fail "-D should deny files under hidden directories, got $deny_short"
-	}
-	printf '%s\n' "$deny_long" | jq -e '.result.content[0].text == "Failed to open file."' >/dev/null 2>&1 || {
-		fail "--deny-hidden-paths should deny files under hidden directories, got $deny_long"
+	printf '%s\n' "$deny_hidden" | jq -e '.result.content[0].text == "Failed to open file."' >/dev/null 2>&1 || {
+		fail "-D should deny files under hidden directories, got $deny_hidden"
 	}
 }
 

--- a/test2.sh
+++ b/test2.sh
@@ -672,6 +672,40 @@ run_sandbox_regressions() {
 	}
 }
 
+run_hidden_path_regression() {
+	local hidden_dir="$TMPDIR/.hidden"
+	local req="$TMPDIR/hidden-path.req"
+	local resp="$TMPDIR/hidden-path.resp"
+	local deny_short_resp="$TMPDIR/hidden-path-deny-short.resp"
+	local deny_long_resp="$TMPDIR/hidden-path-deny-long.resp"
+	mkdir -p "$hidden_dir"
+	cp /bin/ls "$hidden_dir/ls"
+	: > "$req"
+
+	append_request "$req" 1 initialize '{"capabilities":{},"clientInfo":{"name":"testsuite","version":"1"}}'
+	append_notification "$req" notifications/initialized '{}'
+	append_tool_call "$req" 2 open_file "$(jq -cn --arg file "$hidden_dir/ls" '{file_path:$file}')"
+	run_session "$req" "$resp"
+	run_session "$req" "$deny_short_resp" -D
+	run_session "$req" "$deny_long_resp" --deny-hidden-paths
+
+	local open_hidden
+	local deny_short
+	local deny_long
+	open_hidden=$(response_by_id "$resp" 2)
+	deny_short=$(response_by_id "$deny_short_resp" 2)
+	deny_long=$(response_by_id "$deny_long_resp" 2)
+	printf '%s\n' "$open_hidden" | jq -e '.result.content[0].text | contains("File opened")' >/dev/null 2>&1 || {
+		fail "open_file should allow files under hidden directories, got $open_hidden"
+	}
+	printf '%s\n' "$deny_short" | jq -e '.result.content[0].text == "Failed to open file."' >/dev/null 2>&1 || {
+		fail "-D should deny files under hidden directories, got $deny_short"
+	}
+	printf '%s\n' "$deny_long" | jq -e '.result.content[0].text == "Failed to open file."' >/dev/null 2>&1 || {
+		fail "--deny-hidden-paths should deny files under hidden directories, got $deny_long"
+	}
+}
+
 run_command_smoke_regression() {
 	local req="$TMPDIR/runcmd_smoke.req"
 	local resp="$TMPDIR/runcmd_smoke.resp"
@@ -828,6 +862,7 @@ run_open_session_regression
 run_http_sandbox_grain_regression
 run_http_auth_regression
 run_sandbox_regressions
+run_hidden_path_regression
 run_command_smoke_regression
 run_command_json_pagination_regression
 run_command_filter_regression


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The MCP default seems to be to ignore default paths without any errors and any possibility to configure this. Although uncommon, this is weird and doesn't match r2. A file that can be opened via r2 wasn't open with the MCP. This caused my agents to prefer the r2 CLI over the MCP.